### PR TITLE
Implementa protección de rutas para verificar propiedad de reels y stories

### DIFF
--- a/app/reels/[id]/page.tsx
+++ b/app/reels/[id]/page.tsx
@@ -96,7 +96,16 @@ export default function EditReel() {
                     fetchPublicComments(reelData)
                 ]);
             } else {
-                setError('Error al cargar los datos del reel');
+                // Manejar el error específico de permisos - Reel no pertenece al usuario
+                if (reelResponse.statusCode === 403) {
+                    setError('No tienes permisos para acceder a este reel');
+                    // Redirigir a la página principal después de un breve retraso
+                    setTimeout(() => {
+                        router.push('/');
+                    }, 2000);
+                } else {
+                    setError('Error al cargar los datos del reel');
+                }
             }
         } catch (err) {
             setError('Error al cargar los datos del reel');

--- a/app/stories/[id]/page.tsx
+++ b/app/stories/[id]/page.tsx
@@ -47,7 +47,16 @@ export default function EditStory() {
                 setStory(response.data);
                 setDescription(response.data.description || '');
             } else {
-                setError('Error al cargar la story');
+                // Manejar el error específico de permisos - Story no pertenece al usuario
+                if (response.statusCode === 403) {
+                    setError('No tienes permisos para acceder a esta historia');
+                    // Redirigir a la página principal después de un breve retraso
+                    setTimeout(() => {
+                        router.push('/');
+                    }, 2000);
+                } else {
+                    setError('Error al cargar la story');
+                }
             }
         } catch (err) {
             setError('Error al cargar la story');

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -78,26 +78,32 @@ export const getReelDmTotalCount7d = async (reelId: number): Promise<ApiResponse
   return response.json();
 };
 
-export const getReel = async (id: number): Promise<ApiResponse<Media>> => {
+export const getReel = async (id: number): Promise<ApiResponse<Media> & { statusCode?: number }> => {
     const response = await fetch(`${API_URL}/api/reels/${id}`, {
         headers: createAuthHeaders()
     });
     const data = await response.json();
-    if (data.success) {
-        // Convertir el tipo según media_type
-        if (data.data.media_type === 'story') {
-            return {
-                ...data,
-                data: data.data as Story
-            };
-        } else {
-            return {
-                ...data,
-                data: data.data as Reel
-            };
-        }
+    
+    // Si no es exitoso, añadir el código de estado HTTP
+    if (!data.success) {
+        return {
+            ...data,
+            statusCode: response.status
+        };
     }
-    return data;
+    
+    // Si es exitoso, procesar el tipo de datos según sea reel o story
+    if (data.data.media_type === 'story') {
+        return {
+            ...data,
+            data: data.data as Story
+        };
+    } else {
+        return {
+            ...data,
+            data: data.data as Reel
+        };
+    }
 };
 
 export const updateReelDescription = async (id: number, description: string, publish_draft?: boolean, url?: string): Promise<ApiResponse<Media>> => {
@@ -377,11 +383,21 @@ export const getStories = async (): Promise<ApiResponse<Story[]>> => {
     return response.json();
 };
 
-export const getStory = async (id: number): Promise<ApiResponse<Story>> => {
+export const getStory = async (id: number): Promise<ApiResponse<Story> & { statusCode?: number }> => {
     const response = await fetch(`${API_URL}/api/stories/${id}`, {
         headers: createAuthHeaders()
     });
-    return response.json();
+    const data = await response.json();
+    
+    // Si no es exitoso, añadir el código de estado HTTP
+    if (!data.success) {
+        return {
+            ...data,
+            statusCode: response.status
+        };
+    }
+    
+    return data;
 };
 
 export const updateStoryDescription = async (id: number, description: string): Promise<ApiResponse<Story>> => {


### PR DESCRIPTION
Este PR añade verificación de usuario para asegurar que solo el propietario de un reel o story pueda acceder a su página de detalle. Si un usuario intenta acceder a un reel o story que no le pertenece, se devuelve un error 403 y se redirige a la página de inicio.