### PR TITLE
Integración de reels de Instagram

### DIFF
--- a/components/dialogs/InstagramReelsDialog.tsx
+++ b/components/dialogs/InstagramReelsDialog.tsx
@@ -1,9 +1,8 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { InstagramReelsList } from '@/components/reels/InstagramReelsList';
 import { Button } from '@/components/ui/button';
 import Image from 'next/image';
-import { Spinner } from '@/components/ui/Spinner';
 
 interface InstagramReelsDialogProps {
   open: boolean;
@@ -16,21 +15,6 @@ export function InstagramReelsDialog({
   onOpenChange, 
   onSelectReel 
 }: InstagramReelsDialogProps) {
-  const [isLoading, setIsLoading] = useState(true);
-  
-  // Reset loading state when dialog opens
-  useEffect(() => {
-    if (open) {
-      setIsLoading(true);
-      // Simular un tiempo mínimo de carga para mostrar el spinner
-      const timer = setTimeout(() => {
-        setIsLoading(false);
-      }, 500);
-      return () => clearTimeout(timer);
-    }
-  }, [open]);
-  
-  // Cuando se selecciona un reel, notificamos al componente padre
   const handleSelectReel = (url: string, thumbnailUrl: string, caption: string) => {
     onSelectReel(url, thumbnailUrl, caption);
     onOpenChange(false);
@@ -60,14 +44,7 @@ export function InstagramReelsDialog({
         </DialogHeader>
 
         <div className="overflow-y-auto max-h-[60vh] pr-1 pb-4">
-          {isLoading ? (
-            <div className="flex flex-col items-center justify-center min-h-[300px] space-y-4">
-              <div className="h-10 w-10 border-3 border-indigo-500 border-t-transparent rounded-full animate-spin"></div>
-              <p className="text-sm text-gray-400">Cargando tus reels...</p>
-            </div>
-          ) : (
-            <InstagramReelsList onSelectReel={handleSelectReel} />
-          )}
+          <InstagramReelsList onSelectReel={handleSelectReel} />
         </div>
 
         <div className="flex justify-end space-x-3 mt-4 pt-3 border-t border-gray-800">

--- a/components/dialogs/InstagramReelsDialog.tsx
+++ b/components/dialogs/InstagramReelsDialog.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { InstagramReelsList } from '@/components/reels/InstagramReelsList';
 import { Button } from '@/components/ui/button';
 import Image from 'next/image';
+import { Spinner } from '@/components/ui/Spinner';
 
 interface InstagramReelsDialogProps {
   open: boolean;
@@ -15,6 +16,21 @@ export function InstagramReelsDialog({
   onOpenChange, 
   onSelectReel 
 }: InstagramReelsDialogProps) {
+  const [isLoading, setIsLoading] = useState(true);
+  
+  // Reset loading state when dialog opens
+  useEffect(() => {
+    if (open) {
+      setIsLoading(true);
+      // Simular un tiempo mínimo de carga para mostrar el spinner
+      const timer = setTimeout(() => {
+        setIsLoading(false);
+      }, 500);
+      return () => clearTimeout(timer);
+    }
+  }, [open]);
+  
+  // Cuando se selecciona un reel, notificamos al componente padre
   const handleSelectReel = (url: string, thumbnailUrl: string, caption: string) => {
     onSelectReel(url, thumbnailUrl, caption);
     onOpenChange(false);
@@ -44,7 +60,14 @@ export function InstagramReelsDialog({
         </DialogHeader>
 
         <div className="overflow-y-auto max-h-[60vh] pr-1 pb-4">
-          <InstagramReelsList onSelectReel={handleSelectReel} />
+          {isLoading ? (
+            <div className="flex flex-col items-center justify-center min-h-[300px] space-y-4">
+              <div className="h-10 w-10 border-3 border-indigo-500 border-t-transparent rounded-full animate-spin"></div>
+              <p className="text-sm text-gray-400">Cargando tus reels...</p>
+            </div>
+          ) : (
+            <InstagramReelsList onSelectReel={handleSelectReel} />
+          )}
         </div>
 
         <div className="flex justify-end space-x-3 mt-4 pt-3 border-t border-gray-800">

--- a/components/dialogs/InstagramReelsDialog.tsx
+++ b/components/dialogs/InstagramReelsDialog.tsx
@@ -15,24 +15,9 @@ export function InstagramReelsDialog({
   onOpenChange, 
   onSelectReel 
 }: InstagramReelsDialogProps) {
-  const [selectedReelUrl, setSelectedReelUrl] = useState<string | null>(null);
-  const [selectedThumbnailUrl, setSelectedThumbnailUrl] = useState<string>('');
-  const [selectedCaption, setSelectedCaption] = useState<string>('');
-
   const handleSelectReel = (url: string, thumbnailUrl: string, caption: string) => {
-    setSelectedReelUrl(url);
-    setSelectedThumbnailUrl(thumbnailUrl);
-    setSelectedCaption(caption);
-  };
-
-  const handleConfirmSelection = () => {
-    if (selectedReelUrl) {
-      onSelectReel(selectedReelUrl, selectedThumbnailUrl, selectedCaption);
-      onOpenChange(false);
-      setSelectedReelUrl(null);
-      setSelectedThumbnailUrl('');
-      setSelectedCaption('');
-    }
+    onSelectReel(url, thumbnailUrl, caption);
+    onOpenChange(false);
   };
 
   return (
@@ -54,7 +39,7 @@ export function InstagramReelsDialog({
             </DialogTitle>
           </div>
           <DialogDescription className="text-gray-400 mt-1">
-            Selecciona un reel de tu cuenta de Instagram para añadirlo
+            Haz clic en un reel para seleccionarlo
           </DialogDescription>
         </DialogHeader>
 
@@ -70,14 +55,6 @@ export function InstagramReelsDialog({
             className="rounded-md border-gray-700 bg-[#1c1033] text-white hover:bg-[#2c1b4d] px-6 py-2"
           >
             Cancelar
-          </Button>
-          <Button 
-            type="button" 
-            disabled={!selectedReelUrl}
-            onClick={handleConfirmSelection}
-            className="rounded-md bg-indigo-600 text-white hover:bg-indigo-700 px-6 py-2 disabled:opacity-50 disabled:pointer-events-none"
-          >
-            Seleccionar
           </Button>
         </div>
       </DialogContent>

--- a/components/dialogs/InstagramReelsDialog.tsx
+++ b/components/dialogs/InstagramReelsDialog.tsx
@@ -7,7 +7,7 @@ import Image from 'next/image';
 interface InstagramReelsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onSelectReel: (url: string) => void;
+  onSelectReel: (url: string, thumbnailUrl: string, caption: string) => void;
 }
 
 export function InstagramReelsDialog({ 
@@ -16,16 +16,22 @@ export function InstagramReelsDialog({
   onSelectReel 
 }: InstagramReelsDialogProps) {
   const [selectedReelUrl, setSelectedReelUrl] = useState<string | null>(null);
+  const [selectedThumbnailUrl, setSelectedThumbnailUrl] = useState<string>('');
+  const [selectedCaption, setSelectedCaption] = useState<string>('');
 
-  const handleSelectReel = (url: string) => {
+  const handleSelectReel = (url: string, thumbnailUrl: string, caption: string) => {
     setSelectedReelUrl(url);
+    setSelectedThumbnailUrl(thumbnailUrl);
+    setSelectedCaption(caption);
   };
 
   const handleConfirmSelection = () => {
     if (selectedReelUrl) {
-      onSelectReel(selectedReelUrl);
+      onSelectReel(selectedReelUrl, selectedThumbnailUrl, selectedCaption);
       onOpenChange(false);
       setSelectedReelUrl(null);
+      setSelectedThumbnailUrl('');
+      setSelectedCaption('');
     }
   };
 

--- a/components/dialogs/InstagramReelsDialog.tsx
+++ b/components/dialogs/InstagramReelsDialog.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { InstagramReelsList } from '@/components/reels/InstagramReelsList';
+import { Button } from '@/components/ui/button';
+import Image from 'next/image';
+
+interface InstagramReelsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelectReel: (url: string) => void;
+}
+
+export function InstagramReelsDialog({ 
+  open, 
+  onOpenChange, 
+  onSelectReel 
+}: InstagramReelsDialogProps) {
+  const [selectedReelUrl, setSelectedReelUrl] = useState<string | null>(null);
+
+  const handleSelectReel = (url: string) => {
+    setSelectedReelUrl(url);
+  };
+
+  const handleConfirmSelection = () => {
+    if (selectedReelUrl) {
+      onSelectReel(selectedReelUrl);
+      onOpenChange(false);
+      setSelectedReelUrl(null);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent 
+        className="max-w-md md:max-w-xl bg-[#120724] border border-indigo-900/30 rounded-xl shadow-xl"
+      >
+        <DialogHeader className="mb-4">
+          <div className="flex items-center gap-3">
+            <Image
+              src="/images/icons/reel-icon.png"
+              alt="Instagram Icon"
+              width={36}
+              height={36}
+              className="mr-2"
+            />
+            <DialogTitle className="text-xl font-semibold text-white">
+              Tus reels de Instagram
+            </DialogTitle>
+          </div>
+          <DialogDescription className="text-gray-400 mt-1">
+            Selecciona un reel de tu cuenta de Instagram para añadirlo
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="overflow-y-auto max-h-[60vh] pr-1 pb-4">
+          <InstagramReelsList onSelectReel={handleSelectReel} />
+        </div>
+
+        <div className="flex justify-end space-x-3 mt-4 pt-3 border-t border-gray-800">
+          <Button 
+            type="button" 
+            variant="outline" 
+            onClick={() => onOpenChange(false)}
+            className="rounded-md border-gray-700 bg-[#1c1033] text-white hover:bg-[#2c1b4d] px-6 py-2"
+          >
+            Cancelar
+          </Button>
+          <Button 
+            type="button" 
+            disabled={!selectedReelUrl}
+            onClick={handleConfirmSelection}
+            className="rounded-md bg-indigo-600 text-white hover:bg-indigo-700 px-6 py-2 disabled:opacity-50 disabled:pointer-events-none"
+          >
+            Seleccionar
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+} 

--- a/components/media/CreateMediaModal.tsx
+++ b/components/media/CreateMediaModal.tsx
@@ -151,36 +151,48 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
                 <label htmlFor="url" className="block text-sm font-medium text-gray-200 mb-2">
                   URL del Reel
                 </label>
-                <div className="flex items-center gap-2">
-                  <div className="flex-1">
-                    <input
-                      type="url"
-                      name="url"
-                      id="url"
-                      required={!isDraft}
-                      disabled={isDraft}
-                      value={urlValue}
-                      onChange={(e) => setUrlValue(e.target.value)}
-                      className="block w-full rounded-md border-gray-700 bg-[#1c1033] py-2.5 px-3 text-gray-200 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 text-sm disabled:bg-gray-900"
-                      placeholder={isDraft ? "No requerido en modo borrador" : "https://www.instagram.com/reel/..."}
-                    />
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <div className="flex-1">
+                      <input
+                        type="url"
+                        name="url"
+                        id="url"
+                        required={!isDraft}
+                        disabled={isDraft}
+                        value={urlValue}
+                        onChange={(e) => setUrlValue(e.target.value)}
+                        className="block w-full rounded-md border-gray-700 bg-[#1c1033] py-2.5 px-3 text-gray-200 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 text-sm disabled:bg-gray-900"
+                        placeholder={isDraft ? "No requerido en modo borrador" : "https://www.instagram.com/reel/..."}
+                      />
+                    </div>
                   </div>
+                  
                   {!isDraft && (
-                    <Button 
-                      type="button"
-                      variant="outline"
-                      onClick={() => setInstagramReelsDialogOpen(true)}
-                      className="p-2.5 rounded-md border border-indigo-500/50 hover:bg-indigo-600/20"
-                    >
-                      <Instagram className="h-5 w-5 text-indigo-400" />
-                    </Button>
+                    <>
+                      <div className="relative">
+                        <div className="absolute inset-0 flex items-center">
+                          <div className="w-full border-t border-gray-700"></div>
+                        </div>
+                        <div className="relative flex justify-center">
+                          <span className="bg-[#120724] px-2 text-xs text-gray-400">
+                            o
+                          </span>
+                        </div>
+                      </div>
+                      
+                      <Button 
+                        type="button"
+                        variant="outline"
+                        onClick={() => setInstagramReelsDialogOpen(true)}
+                        className="w-full flex items-center justify-center gap-2 py-2.5 rounded-md border border-indigo-500/50 hover:bg-indigo-600/20"
+                      >
+                        <Instagram className="h-5 w-5 text-indigo-400" />
+                        <span className="text-sm text-gray-200">Seleccionar reel de Instagram</span>
+                      </Button>
+                    </>
                   )}
                 </div>
-                {!isDraft && (
-                  <p className="text-xs text-gray-500 mt-1">
-                    Ingresa la URL del reel o selecciona uno de tus reels de Instagram.
-                  </p>
-                )}
               </div>
             )}
 
@@ -234,7 +246,7 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
                       <DocumentTextIcon className="h-4 w-4 opacity-50 mr-1.5" />
                     )}
                     <span className={`text-sm ${isDraft ? 'text-amber-400' : 'text-gray-200'}`}>
-                      {isDraft ? 'Borrador' : 'Publicado'}
+                      {'Draft'}
                     </span>
                   </Toggle>
                 )}

--- a/components/media/CreateMediaModal.tsx
+++ b/components/media/CreateMediaModal.tsx
@@ -28,7 +28,6 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
   const [selectedThumbnailUrl, setSelectedThumbnailUrl] = useState<string>('');
   const [selectedReelCaption, setSelectedReelCaption] = useState<string>('');
   const [showThumbnail, setShowThumbnail] = useState(false);
-  const [loadingReelsDialog, setLoadingReelsDialog] = useState(false);
 
   const isReelType = mediaType === 'reel';
 
@@ -113,20 +112,6 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
     // Si está en modo borrador y selecciona un reel, desactivar el modo borrador
     if (isDraft) {
       setIsDraft(false);
-    }
-  };
-
-  // Manejar la apertura del diálogo de reels con un estado de carga
-  const handleOpenReelsDialog = () => {
-    setLoadingReelsDialog(true);
-    setInstagramReelsDialogOpen(true);
-  };
-
-  // Cuando se cierra el diálogo de reels, resetear el estado de carga
-  const handleReelsDialogOpenChange = (open: boolean) => {
-    setInstagramReelsDialogOpen(open);
-    if (!open) {
-      setLoadingReelsDialog(false);
     }
   };
 
@@ -235,17 +220,11 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
                       <Button 
                         type="button"
                         variant="outline"
-                        onClick={handleOpenReelsDialog}
+                        onClick={() => setInstagramReelsDialogOpen(true)}
                         className="w-full flex items-center justify-center gap-2 py-2.5 rounded-md border border-indigo-500/50 hover:bg-indigo-600/20"
                       >
-                        {loadingReelsDialog ? (
-                          <div className="h-5 w-5 border-2 border-indigo-400 border-t-transparent rounded-full animate-spin"></div>
-                        ) : (
-                          <Instagram className="h-5 w-5 text-indigo-400" />
-                        )}
-                        <span className="text-sm text-gray-200">
-                          {loadingReelsDialog ? 'Cargando reels...' : 'Seleccionar reel de Instagram'}
-                        </span>
+                        <Instagram className="h-5 w-5 text-indigo-400" />
+                        <span className="text-sm text-gray-200">Seleccionar reel de Instagram</span>
                       </Button>
                     </>
                   )}
@@ -346,7 +325,7 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
 
       <InstagramReelsDialog 
         open={instagramReelsDialogOpen}
-        onOpenChange={handleReelsDialogOpenChange}
+        onOpenChange={setInstagramReelsDialogOpen}
         onSelectReel={handleInstagramReelSelect}
       />
     </>

--- a/components/media/CreateMediaModal.tsx
+++ b/components/media/CreateMediaModal.tsx
@@ -257,6 +257,18 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
               </div>
             </div>
 
+            {isDraft && (
+              <div className="mt-3 p-3 text-xs rounded-md bg-amber-900/20 border border-amber-500/30 text-amber-300">
+                <p className="flex items-center">
+                  <DocumentTextIcon className="h-4 w-4 mr-2 text-amber-400" />
+                  <span>
+                    El modo Draft te permite preparar la automatización (respuestas, palabras clave) antes de publicar el reel. 
+                    Una vez que publiques tu reel en Instagram, solo tendrás que añadir la URL y desactivar el modo Draft.
+                  </span>
+                </p>
+              </div>
+            )}
+
             <div className="flex justify-end space-x-3 mt-6 pt-3">
               <Button 
                 type="button" 

--- a/components/media/CreateMediaModal.tsx
+++ b/components/media/CreateMediaModal.tsx
@@ -259,12 +259,9 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
 
             {isDraft && (
               <div className="mt-3 p-3 text-xs rounded-md bg-amber-900/20 border border-amber-500/30 text-amber-300">
-                <p className="flex items-center">
-                  <DocumentTextIcon className="h-4 w-4 mr-2 text-amber-400" />
-                  <span>
-                    El modo Draft te permite preparar la automatización (respuestas, palabras clave) antes de publicar el reel. 
-                    Una vez que publiques tu reel en Instagram, solo tendrás que añadir la URL y desactivar el modo Draft.
-                  </span>
+                <p>
+                  El modo Draft te permite preparar la automatización (respuestas, palabras clave) antes de publicar el reel. 
+                  Una vez que publiques tu reel en Instagram, añade la URL o selecciona el reel y el modo Draft se desactivará automáticamente.
                 </p>
               </div>
             )}

--- a/components/media/CreateMediaModal.tsx
+++ b/components/media/CreateMediaModal.tsx
@@ -5,9 +5,10 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { Button } from '@/components/ui/button';
 import { Toggle } from '@/components/ui/toggle';
 import { DocumentTextIcon } from '@heroicons/react/24/outline';
-import { Play, Pause } from 'lucide-react';
+import { Instagram, Play, Pause } from 'lucide-react';
 import { createReel, createStory } from '@/lib/api';
 import Image from 'next/image';
+import { InstagramReelsDialog } from '@/components/dialogs/InstagramReelsDialog';
 
 interface CreateMediaModalProps {
   open: boolean;
@@ -23,6 +24,7 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
   const [isActive, setIsActive] = useState(true);
   const [urlValue, setUrlValue] = useState('');
   const [description, setDescription] = useState('');
+  const [instagramReelsDialogOpen, setInstagramReelsDialogOpen] = useState(false);
 
   const isReelType = mediaType === 'reel';
 
@@ -92,145 +94,179 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
     setIsActive(!isActive);
   };
 
+  const handleInstagramReelSelect = (reelUrl: string) => {
+    setUrlValue(reelUrl);
+    
+    // Si está en modo borrador y selecciona un reel, desactivar el modo borrador
+    if (isDraft) {
+      setIsDraft(false);
+    }
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent 
-        className={`max-w-md bg-[#120724] ${isReelType && isDraft 
-          ? 'border-2 border-amber-500/70' 
-          : 'border border-indigo-900/30'
-        } rounded-xl shadow-xl`}
-      >
-        <DialogHeader className="mb-4">
-          <div className="flex items-center gap-3">
-            <Image
-              src={`/images/icons/${isReelType ? 'reel' : 'story'}-icon.png`}
-              alt={isReelType ? "Reel Icon" : "Story Icon"}
-              width={36}
-              height={36}
-              className="mr-2"
-            />
-            <DialogTitle className="text-xl font-semibold text-white">
-              {isReelType ? 'Nuevo Reel' : 'Nueva Historia'}
-              {isReelType && isDraft && (
-                <span className="inline-flex items-center rounded-md px-2.5 py-1 ml-2 text-xs font-medium text-amber-400 bg-[#120724] border border-amber-500/70">
-                  DRAFT
-                </span>
-              )}
-            </DialogTitle>
-          </div>
-          <DialogDescription className="text-gray-400 mt-1">
-            {isReelType 
-              ? 'Añade un nuevo reel para configurar respuestas automáticas' 
-              : 'Añade una nueva historia para configurar respuestas automáticas'
-            }
-          </DialogDescription>
-        </DialogHeader>
-
-        <form onSubmit={handleSubmit} className="space-y-5">
-          {error && (
-            <div className="bg-red-900/20 border border-red-800 text-red-400 px-4 py-3 rounded relative" role="alert">
-              <strong className="font-bold">Error!</strong>
-              <span className="block sm:inline"> {error}</span>
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent 
+          className={`max-w-md bg-[#120724] ${isReelType && isDraft 
+            ? 'border-2 border-amber-500/70' 
+            : 'border border-indigo-900/30'
+          } rounded-xl shadow-xl`}
+        >
+          <DialogHeader className="mb-4">
+            <div className="flex items-center gap-3">
+              <Image
+                src={`/images/icons/${isReelType ? 'reel' : 'story'}-icon.png`}
+                alt={isReelType ? "Reel Icon" : "Story Icon"}
+                width={36}
+                height={36}
+                className="mr-2"
+              />
+              <DialogTitle className="text-xl font-semibold text-white">
+                {isReelType ? 'Nuevo Reel' : 'Nueva Historia'}
+                {isReelType && isDraft && (
+                  <span className="inline-flex items-center rounded-md px-2.5 py-1 ml-2 text-xs font-medium text-amber-400 bg-[#120724] border border-amber-500/70">
+                    DRAFT
+                  </span>
+                )}
+              </DialogTitle>
             </div>
-          )}
+            <DialogDescription className="text-gray-400 mt-1">
+              {isReelType 
+                ? 'Añade un nuevo reel para configurar respuestas automáticas' 
+                : 'Añade una nueva historia para configurar respuestas automáticas'
+              }
+            </DialogDescription>
+          </DialogHeader>
 
-          {isReelType && (
+          <form onSubmit={handleSubmit} className="space-y-5">
+            {error && (
+              <div className="bg-red-900/20 border border-red-800 text-red-400 px-4 py-3 rounded relative" role="alert">
+                <strong className="font-bold">Error!</strong>
+                <span className="block sm:inline"> {error}</span>
+              </div>
+            )}
+
+            {isReelType && (
+              <div>
+                <label htmlFor="url" className="block text-sm font-medium text-gray-200 mb-2">
+                  URL del Reel
+                </label>
+                <div className="flex items-center gap-2">
+                  <div className="flex-1">
+                    <input
+                      type="url"
+                      name="url"
+                      id="url"
+                      required={!isDraft}
+                      disabled={isDraft}
+                      value={urlValue}
+                      onChange={(e) => setUrlValue(e.target.value)}
+                      className="block w-full rounded-md border-gray-700 bg-[#1c1033] py-2.5 px-3 text-gray-200 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 text-sm disabled:bg-gray-900"
+                      placeholder={isDraft ? "No requerido en modo borrador" : "https://www.instagram.com/reel/..."}
+                    />
+                  </div>
+                  {!isDraft && (
+                    <Button 
+                      type="button"
+                      variant="outline"
+                      onClick={() => setInstagramReelsDialogOpen(true)}
+                      className="p-2.5 rounded-md border border-indigo-500/50 hover:bg-indigo-600/20"
+                    >
+                      <Instagram className="h-5 w-5 text-indigo-400" />
+                    </Button>
+                  )}
+                </div>
+                {!isDraft && (
+                  <p className="text-xs text-gray-500 mt-1">
+                    Ingresa la URL del reel o selecciona uno de tus reels de Instagram.
+                  </p>
+                )}
+              </div>
+            )}
+
             <div>
-              <label htmlFor="url" className="block text-sm font-medium text-gray-200 mb-2">
-                URL del Reel
+              <label htmlFor="description" className="block text-sm font-medium text-gray-200 mb-2">
+                Descripción
               </label>
               <div>
-                <input
-                  type="url"
-                  name="url"
-                  id="url"
-                  required={!isDraft}
-                  disabled={isDraft}
-                  value={urlValue}
-                  onChange={(e) => setUrlValue(e.target.value)}
-                  className="block w-full rounded-md border-gray-700 bg-[#1c1033] py-2.5 px-3 text-gray-200 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 text-sm disabled:bg-gray-900"
-                  placeholder={isDraft ? "No requerido en modo borrador" : "https://www.instagram.com/reel/..."}
+                <textarea
+                  name="description"
+                  id="description"
+                  rows={3}
+                  required={true}
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  className="block w-full rounded-md border-gray-700 bg-[#1c1033] py-2.5 px-3 text-gray-200 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 text-sm"
+                  placeholder={`Descripción ${isReelType ? 'del reel' : 'de la historia'}...`}
                 />
               </div>
             </div>
-          )}
 
-          <div>
-            <label htmlFor="description" className="block text-sm font-medium text-gray-200 mb-2">
-              Descripción
-            </label>
-            <div>
-              <textarea
-                name="description"
-                id="description"
-                rows={3}
-                required={true}
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                className="block w-full rounded-md border-gray-700 bg-[#1c1033] py-2.5 px-3 text-gray-200 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 text-sm"
-                placeholder={`Descripción ${isReelType ? 'del reel' : 'de la historia'}...`}
-              />
-            </div>
-          </div>
-
-          {/* Controles */}
-          <div className="flex justify-end space-x-3 pt-2">
-            <div className="flex items-center space-x-3">
-              <Toggle
-                id="is_active"
-                pressed={isActive}
-                onPressedChange={handleActiveChange}
-                className="flex items-center space-x-2 bg-[#1c1033] hover:bg-[#2c1b4d] border border-gray-700 rounded-md px-3 py-1.5"
-              >
-                {isActive ? (
-                  <Play className="h-4 w-4 mr-1.5 text-green-500" />
-                ) : (
-                  <Pause className="h-4 w-4 mr-1.5 text-amber-500" />
-                )}
-                <span className="text-sm text-gray-200">
-                  {isActive ? 'Activo' : 'Inactivo'}
-                </span>
-              </Toggle>
-              
-              {isReelType && (
+            {/* Controles */}
+            <div className="flex justify-end space-x-3 pt-2">
+              <div className="flex items-center space-x-3">
                 <Toggle
-                  id="is_draft"
-                  pressed={isDraft}
-                  onPressedChange={handleDraftChange}
-                  className={`flex items-center space-x-2 bg-[#1c1033] hover:bg-[#2c1b4d] border ${isDraft ? 'border-amber-500/70' : 'border-gray-700'} rounded-md px-3 py-1.5`}
+                  id="is_active"
+                  pressed={isActive}
+                  onPressedChange={handleActiveChange}
+                  className="flex items-center space-x-2 bg-[#1c1033] hover:bg-[#2c1b4d] border border-gray-700 rounded-md px-3 py-1.5"
                 >
-                  {isDraft ? (
-                    <DocumentTextIcon className="h-4 w-4 text-amber-400 mr-1.5" />
+                  {isActive ? (
+                    <Play className="h-4 w-4 mr-1.5 text-green-500" />
                   ) : (
-                    <DocumentTextIcon className="h-4 w-4 opacity-50 mr-1.5" />
+                    <Pause className="h-4 w-4 mr-1.5 text-amber-500" />
                   )}
-                  <span className={`text-sm ${isDraft ? 'text-amber-400' : 'text-gray-200'}`}>
-                    {isDraft ? 'Borrador' : 'Publicado'}
+                  <span className="text-sm text-gray-200">
+                    {isActive ? 'Activo' : 'Inactivo'}
                   </span>
                 </Toggle>
-              )}
+                
+                {isReelType && (
+                  <Toggle
+                    id="is_draft"
+                    pressed={isDraft}
+                    onPressedChange={handleDraftChange}
+                    className={`flex items-center space-x-2 bg-[#1c1033] hover:bg-[#2c1b4d] border ${isDraft ? 'border-amber-500/70' : 'border-gray-700'} rounded-md px-3 py-1.5`}
+                  >
+                    {isDraft ? (
+                      <DocumentTextIcon className="h-4 w-4 text-amber-400 mr-1.5" />
+                    ) : (
+                      <DocumentTextIcon className="h-4 w-4 opacity-50 mr-1.5" />
+                    )}
+                    <span className={`text-sm ${isDraft ? 'text-amber-400' : 'text-gray-200'}`}>
+                      {isDraft ? 'Borrador' : 'Publicado'}
+                    </span>
+                  </Toggle>
+                )}
+              </div>
             </div>
-          </div>
 
-          <div className="flex justify-end space-x-3 mt-6 pt-3">
-            <Button 
-              type="button" 
-              variant="outline" 
-              onClick={handleCloseModal}
-              className="rounded-md border-gray-700 bg-[#1c1033] text-white hover:bg-[#2c1b4d] px-8 py-2.5"
-            >
-              Cancelar
-            </Button>
-            <Button 
-              type="submit" 
-              disabled={loading}
-              className="rounded-md bg-indigo-600 text-white hover:bg-indigo-700 px-8 py-2.5"
-            >
-              {loading ? 'Guardando...' : 'Guardar'}
-            </Button>
-          </div>
-        </form>
-      </DialogContent>
-    </Dialog>
+            <div className="flex justify-end space-x-3 mt-6 pt-3">
+              <Button 
+                type="button" 
+                variant="outline" 
+                onClick={handleCloseModal}
+                className="rounded-md border-gray-700 bg-[#1c1033] text-white hover:bg-[#2c1b4d] px-8 py-2.5"
+              >
+                Cancelar
+              </Button>
+              <Button 
+                type="submit" 
+                disabled={loading}
+                className="rounded-md bg-indigo-600 text-white hover:bg-indigo-700 px-8 py-2.5"
+              >
+                {loading ? 'Guardando...' : 'Guardar'}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <InstagramReelsDialog 
+        open={instagramReelsDialogOpen}
+        onOpenChange={setInstagramReelsDialogOpen}
+        onSelectReel={handleInstagramReelSelect}
+      />
+    </>
   );
 } 

--- a/components/media/CreateMediaModal.tsx
+++ b/components/media/CreateMediaModal.tsx
@@ -25,6 +25,9 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
   const [urlValue, setUrlValue] = useState('');
   const [description, setDescription] = useState('');
   const [instagramReelsDialogOpen, setInstagramReelsDialogOpen] = useState(false);
+  const [selectedThumbnailUrl, setSelectedThumbnailUrl] = useState<string>('');
+  const [selectedReelCaption, setSelectedReelCaption] = useState<string>('');
+  const [showThumbnail, setShowThumbnail] = useState(false);
 
   const isReelType = mediaType === 'reel';
 
@@ -76,6 +79,9 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
     setIsDraft(false);
     setIsActive(true);
     setError(null);
+    setSelectedThumbnailUrl('');
+    setSelectedReelCaption('');
+    setShowThumbnail(false);
   };
 
   const handleCloseModal = () => {
@@ -94,8 +100,11 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
     setIsActive(!isActive);
   };
 
-  const handleInstagramReelSelect = (reelUrl: string) => {
+  const handleInstagramReelSelect = (reelUrl: string, thumbnailUrl: string, caption: string) => {
     setUrlValue(reelUrl);
+    setSelectedThumbnailUrl(thumbnailUrl);
+    setSelectedReelCaption(caption);
+    setShowThumbnail(!!thumbnailUrl);
     
     // Si está en modo borrador y selecciona un reel, desactivar el modo borrador
     if (isDraft) {
@@ -119,10 +128,10 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
                 alt={isReelType ? "Reel Icon" : "Story Icon"}
                 width={36}
                 height={36}
-                className="mr-2"
+                className="mr-[-10px]"
               />
               <DialogTitle className="text-xl font-semibold text-white">
-                {isReelType ? 'Nuevo Reel' : 'Nueva Historia'}
+                {isReelType ? 'Nueva automatización de Reel' : 'Nueva automatización de Historia'}
                 {isReelType && isDraft && (
                   <span className="inline-flex items-center rounded-md px-2.5 py-1 ml-2 text-xs font-medium text-amber-400 bg-[#120724] border border-amber-500/70">
                     DRAFT
@@ -161,13 +170,37 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
                         required={!isDraft}
                         disabled={isDraft}
                         value={urlValue}
-                        onChange={(e) => setUrlValue(e.target.value)}
+                        onChange={(e) => {
+                          setUrlValue(e.target.value);
+                          // Si se borra la URL, quitar la miniatura
+                          if (!e.target.value) {
+                            setShowThumbnail(false);
+                          }
+                        }}
                         className="block w-full rounded-md border-gray-700 bg-[#1c1033] py-2.5 px-3 text-gray-200 shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 text-sm disabled:bg-gray-900"
                         placeholder={isDraft ? "No requerido en modo borrador" : "https://www.instagram.com/reel/..."}
                       />
                     </div>
                   </div>
                   
+                  {/* Añadir miniatura si está disponible */}
+                  {!isDraft && showThumbnail && selectedThumbnailUrl && (
+                    <div className="flex items-center p-2 bg-[#1c1033]/50 rounded-md mt-2">
+                      <div className="relative w-16 h-28 overflow-hidden rounded-md mr-3">
+                        <Image 
+                          src={selectedThumbnailUrl}
+                          alt="Vista previa del reel"
+                          fill
+                          className="object-cover"
+                        />
+                      </div>
+                      <div className="flex-1">
+                        <p className="text-xs text-gray-300 font-medium mb-1">Reel seleccionado:</p>
+                        <p className="text-xs text-gray-400 line-clamp-2">{selectedReelCaption}</p>
+                      </div>
+                    </div>
+                  )}
+
                   {!isDraft && (
                     <>
                       <div className="relative">

--- a/components/media/CreateMediaModal.tsx
+++ b/components/media/CreateMediaModal.tsx
@@ -93,6 +93,9 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
     setIsDraft(!isDraft);
     if (!isDraft) {
       setUrlValue('');
+      setShowThumbnail(false);
+      setSelectedThumbnailUrl('');
+      setSelectedReelCaption('');
     }
   };
 

--- a/components/media/CreateMediaModal.tsx
+++ b/components/media/CreateMediaModal.tsx
@@ -20,7 +20,7 @@ interface CreateMediaModalProps {
 export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: CreateMediaModalProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isDraft, setIsDraft] = useState(true);
+  const [isDraft, setIsDraft] = useState(false);
   const [isActive, setIsActive] = useState(true);
   const [urlValue, setUrlValue] = useState('');
   const [description, setDescription] = useState('');
@@ -73,7 +73,7 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
   const resetForm = () => {
     setUrlValue('');
     setDescription('');
-    setIsDraft(true);
+    setIsDraft(false);
     setIsActive(true);
     setError(null);
   };

--- a/components/media/CreateMediaModal.tsx
+++ b/components/media/CreateMediaModal.tsx
@@ -28,6 +28,7 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
   const [selectedThumbnailUrl, setSelectedThumbnailUrl] = useState<string>('');
   const [selectedReelCaption, setSelectedReelCaption] = useState<string>('');
   const [showThumbnail, setShowThumbnail] = useState(false);
+  const [loadingReelsDialog, setLoadingReelsDialog] = useState(false);
 
   const isReelType = mediaType === 'reel';
 
@@ -112,6 +113,20 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
     // Si está en modo borrador y selecciona un reel, desactivar el modo borrador
     if (isDraft) {
       setIsDraft(false);
+    }
+  };
+
+  // Manejar la apertura del diálogo de reels con un estado de carga
+  const handleOpenReelsDialog = () => {
+    setLoadingReelsDialog(true);
+    setInstagramReelsDialogOpen(true);
+  };
+
+  // Cuando se cierra el diálogo de reels, resetear el estado de carga
+  const handleReelsDialogOpenChange = (open: boolean) => {
+    setInstagramReelsDialogOpen(open);
+    if (!open) {
+      setLoadingReelsDialog(false);
     }
   };
 
@@ -220,11 +235,17 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
                       <Button 
                         type="button"
                         variant="outline"
-                        onClick={() => setInstagramReelsDialogOpen(true)}
+                        onClick={handleOpenReelsDialog}
                         className="w-full flex items-center justify-center gap-2 py-2.5 rounded-md border border-indigo-500/50 hover:bg-indigo-600/20"
                       >
-                        <Instagram className="h-5 w-5 text-indigo-400" />
-                        <span className="text-sm text-gray-200">Seleccionar reel de Instagram</span>
+                        {loadingReelsDialog ? (
+                          <div className="h-5 w-5 border-2 border-indigo-400 border-t-transparent rounded-full animate-spin"></div>
+                        ) : (
+                          <Instagram className="h-5 w-5 text-indigo-400" />
+                        )}
+                        <span className="text-sm text-gray-200">
+                          {loadingReelsDialog ? 'Cargando reels...' : 'Seleccionar reel de Instagram'}
+                        </span>
                       </Button>
                     </>
                   )}
@@ -325,7 +346,7 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
 
       <InstagramReelsDialog 
         open={instagramReelsDialogOpen}
-        onOpenChange={setInstagramReelsDialogOpen}
+        onOpenChange={handleReelsDialogOpenChange}
         onSelectReel={handleInstagramReelSelect}
       />
     </>

--- a/components/media/CreateMediaModal.tsx
+++ b/components/media/CreateMediaModal.tsx
@@ -221,14 +221,18 @@ export function CreateMediaModal({ open, onOpenChange, mediaType, onSuccess }: C
                   id="is_active"
                   pressed={isActive}
                   onPressedChange={handleActiveChange}
-                  className="flex items-center space-x-2 bg-[#1c1033] hover:bg-[#2c1b4d] border border-gray-700 rounded-md px-3 py-1.5"
+                  className={`flex items-center space-x-2 bg-[#1c1033] hover:bg-[#2c1b4d] border ${
+                    isActive 
+                      ? 'border-green-500 text-green-500' 
+                      : 'border-red-500 text-red-500'
+                  } rounded-md px-3 py-1.5`}
                 >
                   {isActive ? (
                     <Play className="h-4 w-4 mr-1.5 text-green-500" />
                   ) : (
-                    <Pause className="h-4 w-4 mr-1.5 text-amber-500" />
+                    <Pause className="h-4 w-4 mr-1.5 text-red-500" />
                   )}
-                  <span className="text-sm text-gray-200">
+                  <span className={`text-sm ${isActive ? 'text-green-500' : 'text-red-500'}`}>
                     {isActive ? 'Activo' : 'Inactivo'}
                   </span>
                 </Toggle>

--- a/components/reels/InstagramReelsList.tsx
+++ b/components/reels/InstagramReelsList.tsx
@@ -3,6 +3,7 @@ import { getUserInstagramReels } from '@/lib/api';
 import Image from 'next/image';
 import { motion } from 'framer-motion';
 import { Spinner } from '@/components/ui/Spinner';
+import { Skeleton } from '@/components/ui/skeleton';
 
 interface InstagramReel {
   id: string;
@@ -57,8 +58,28 @@ export const InstagramReelsList = ({ onSelectReel }: InstagramReelsListProps) =>
 
   if (loading) {
     return (
-      <div className="flex justify-center items-center min-h-[300px]">
-        <Spinner size="lg" />
+      <div className="space-y-4">
+        {/* Skeleton para la info de la cuenta */}
+        <div className="flex items-center space-x-3 mb-4">
+          <Skeleton className="w-10 h-10 rounded-full" />
+          <div className="flex-1">
+            <Skeleton className="h-5 w-40 mb-2" />
+            <Skeleton className="h-3 w-24" />
+          </div>
+        </div>
+        
+        {/* Grid de skeletons para los reels */}
+        <div className="grid grid-cols-2 gap-3">
+          {Array(6).fill(0).map((_, index) => (
+            <div key={index} className="relative aspect-[9/16] rounded-lg overflow-hidden">
+              <Skeleton className="w-full h-full" />
+              <div className="absolute bottom-0 left-0 right-0 p-2">
+                <Skeleton className="h-3 w-full mb-1" />
+                <Skeleton className="h-2 w-2/3" />
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
     );
   }

--- a/components/reels/InstagramReelsList.tsx
+++ b/components/reels/InstagramReelsList.tsx
@@ -1,0 +1,144 @@
+import { useState, useEffect } from 'react';
+import { getUserInstagramReels } from '@/lib/api';
+import Image from 'next/image';
+import { motion } from 'framer-motion';
+import { Spinner } from '@/components/ui/Spinner';
+
+interface InstagramReel {
+  id: string;
+  caption: string;
+  media_type: string;
+  media_url: string;
+  permalink: string;
+  thumbnail_url: string;
+  timestamp: string;
+  shortcode: string;
+}
+
+interface InstagramAccount {
+  id: string;
+  username: string;
+  profile_picture_url: string;
+  media_count: number;
+}
+
+interface InstagramReelsListProps {
+  onSelectReel: (url: string) => void;
+}
+
+export const InstagramReelsList = ({ onSelectReel }: InstagramReelsListProps) => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reels, setReels] = useState<InstagramReel[]>([]);
+  const [account, setAccount] = useState<InstagramAccount | null>(null);
+
+  useEffect(() => {
+    const fetchReels = async () => {
+      try {
+        setLoading(true);
+        const response = await getUserInstagramReels(10);
+        
+        if (response.success && response.data) {
+          setReels(response.data.reels);
+          setAccount(response.data.instagram_account);
+        } else {
+          setError(response.message || 'Error al obtener los reels');
+        }
+      } catch (error) {
+        setError('Error al cargar los reels de Instagram');
+        console.error('Error fetching Instagram reels:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchReels();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-[300px]">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 p-4 rounded-lg text-red-600 text-center">
+        <p>{error}</p>
+        <p className="text-sm mt-2">Por favor intenta de nuevo más tarde o añade el reel manualmente.</p>
+      </div>
+    );
+  }
+
+  if (!account) {
+    return (
+      <div className="bg-yellow-50 p-4 rounded-lg text-yellow-700 text-center">
+        <p>No se pudo obtener información de tu cuenta de Instagram.</p>
+        <p className="text-sm mt-2">¿Has conectado tu cuenta de Instagram?</p>
+      </div>
+    );
+  }
+
+  if (reels.length === 0) {
+    return (
+      <div className="bg-blue-50 p-4 rounded-lg text-blue-700 text-center">
+        <p>No se encontraron reels en tu cuenta de Instagram.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center space-x-3 mb-4">
+        {account.profile_picture_url && (
+          <div className="relative w-10 h-10 rounded-full overflow-hidden">
+            <Image 
+              src={account.profile_picture_url} 
+              alt={account.username} 
+              fill 
+              className="object-cover"
+            />
+          </div>
+        )}
+        <div>
+          <h3 className="font-medium">@{account.username}</h3>
+          <p className="text-xs text-gray-500">{account.media_count} publicaciones</p>
+        </div>
+      </div>
+      
+      <div className="grid grid-cols-2 gap-3">
+        {reels.map((reel) => (
+          <motion.div
+            key={reel.id}
+            whileHover={{ scale: 1.03 }}
+            whileTap={{ scale: 0.98 }}
+            className="relative aspect-[9/16] bg-gray-100 rounded-lg overflow-hidden cursor-pointer"
+            onClick={() => onSelectReel(reel.permalink)}
+          >
+            {reel.thumbnail_url ? (
+              <Image
+                src={reel.thumbnail_url}
+                alt={reel.caption || 'Instagram Reel'}
+                fill
+                className="object-cover"
+              />
+            ) : (
+              <div className="flex items-center justify-center h-full">
+                <span className="text-gray-500 text-sm">Sin vista previa</span>
+              </div>
+            )}
+            <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-2">
+              <p className="text-white text-xs truncate">
+                {reel.caption || 'Sin descripción'}
+              </p>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default InstagramReelsList; 

--- a/components/reels/InstagramReelsList.tsx
+++ b/components/reels/InstagramReelsList.tsx
@@ -23,7 +23,7 @@ interface InstagramAccount {
 }
 
 interface InstagramReelsListProps {
-  onSelectReel: (url: string) => void;
+  onSelectReel: (url: string, thumbnailUrl: string, caption: string) => void;
 }
 
 export const InstagramReelsList = ({ onSelectReel }: InstagramReelsListProps) => {
@@ -115,7 +115,7 @@ export const InstagramReelsList = ({ onSelectReel }: InstagramReelsListProps) =>
             whileHover={{ scale: 1.03 }}
             whileTap={{ scale: 0.98 }}
             className="relative aspect-[9/16] bg-gray-100 rounded-lg overflow-hidden cursor-pointer"
-            onClick={() => onSelectReel(reel.permalink)}
+            onClick={() => onSelectReel(reel.permalink, reel.thumbnail_url || '', reel.caption || 'Reel de Instagram')}
           >
             {reel.thumbnail_url ? (
               <Image

--- a/components/ui/Spinner.tsx
+++ b/components/ui/Spinner.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+interface SpinnerProps {
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+export const Spinner = ({ size = 'md', className }: SpinnerProps) => {
+  const sizeClasses = {
+    sm: 'w-4 h-4 border-2',
+    md: 'w-6 h-6 border-2',
+    lg: 'w-8 h-8 border-3',
+  };
+
+  return (
+    <div
+      className={cn(
+        "animate-spin rounded-full border-t-transparent border-primary",
+        sizeClasses[size],
+        className
+      )}
+    />
+  );
+}; 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -683,6 +683,57 @@ export const loginWithGoogle = async (idToken: string): Promise<AuthResponse> =>
   }
 };
 
+/**
+ * Obtiene los reels de Instagram del usuario autenticado
+ * @param limit Número máximo de reels a obtener (opcional)
+ * @returns ApiResponse con la cuenta de Instagram y los reels
+ */
+export const getUserInstagramReels = async (limit?: number): Promise<ApiResponse<{
+  instagram_account: {
+    id: string;
+    username: string;
+    profile_picture_url: string;
+    media_count: number;
+  };
+  reels: Array<{
+    id: string;
+    caption: string;
+    media_type: string;
+    media_url: string;
+    permalink: string;
+    thumbnail_url: string;
+    timestamp: string;
+    shortcode: string;
+  }>;
+}>> => {
+  try {
+    const queryParams = limit ? `?limit=${limit}` : '';
+    const response = await fetch(`${API_URL}/api/auth/instagram/reels${queryParams}`, {
+      method: 'GET',
+      headers: createAuthHeaders(),
+    });
+
+    if (!response.ok) {
+      console.error('Error al obtener reels de Instagram:', response.status, response.statusText);
+      return { 
+        success: false, 
+        data: null as any, 
+        message: `Error ${response.status}: ${response.statusText}` 
+      };
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error('Error en la petición para obtener reels de Instagram:', error);
+    return { 
+      success: false, 
+      data: null as any, 
+      message: 'Error de red al obtener los reels de Instagram' 
+    };
+  }
+};
+
 export const logout = () => {
     localStorage.removeItem('token');
     window.location.href = '/login';

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -686,9 +686,10 @@ export const loginWithGoogle = async (idToken: string): Promise<AuthResponse> =>
 /**
  * Obtiene los reels de Instagram del usuario autenticado
  * @param limit Número máximo de reels a obtener (opcional)
+ * @param afterCursor ID del último reel para paginación (opcional)
  * @returns ApiResponse con la cuenta de Instagram y los reels
  */
-export const getUserInstagramReels = async (limit?: number): Promise<ApiResponse<{
+export const getUserInstagramReels = async (limit?: number, afterCursor?: string): Promise<ApiResponse<{
   instagram_account: {
     id: string;
     username: string;
@@ -705,10 +706,19 @@ export const getUserInstagramReels = async (limit?: number): Promise<ApiResponse
     timestamp: string;
     shortcode: string;
   }>;
+  pagination: {
+    has_next_page: boolean;
+    next_cursor: string | null;
+  };
 }>> => {
   try {
-    const queryParams = limit ? `?limit=${limit}` : '';
-    const response = await fetch(`${API_URL}/api/auth/instagram/reels${queryParams}`, {
+    const queryParams = new URLSearchParams();
+    if (limit) queryParams.append('limit', limit.toString());
+    if (afterCursor) queryParams.append('after', afterCursor);
+    
+    const url = `${API_URL}/api/auth/instagram/reels${queryParams.toString() ? `?${queryParams.toString()}` : ''}`;
+    
+    const response = await fetch(url, {
       method: 'GET',
       headers: createAuthHeaders(),
     });

--- a/next.config.js
+++ b/next.config.js
@@ -19,7 +19,8 @@ const nextConfig = {
       'instagram.com',
       'ggrjdxfnoqnqsohqmalh.supabase.co',
       'lh3.googleusercontent.com',
-      'platform-lookaside.fbsbx.com'
+      'platform-lookaside.fbsbx.com',
+      'scontent-mad1-1.xx.fbcdn.net'
     ],
     remotePatterns: [
       {
@@ -37,6 +38,10 @@ const nextConfig = {
       {
         protocol: 'https',
         hostname: 'platform-lookaside.fbsbx.com',
+      },
+      {
+        protocol: 'https',
+        hostname: '*.xx.fbcdn.net',
       },
     ],
   },


### PR DESCRIPTION
Esta PR añade la funcionalidad para obtener y seleccionar reels de Instagram directamente desde la aplicación.\n\n## Cambios realizados\n\n- Creación de la función getUserInstagramReels en api.ts\n- Implementación del componente InstagramReelsList para mostrar los reels del usuario\n- Creación del componente Spinner reutilizable\n- Implementación del diálogo InstagramReelsDialog para seleccionar reels\n- Actualización del modal de creación de reels para incluir un botón de Instagram\n- Configuración de next.config.js para permitir imágenes de Instagram/Facebook\n\n## Notas\n\nEs necesario implementar el endpoint en el backend para obtener los reels de Instagram. La ruta esperada es: /api/auth/instagram/reels